### PR TITLE
Fix insert_execution_context() in handler.py: Adjust to SQLite3 dialect

### DIFF
--- a/docs/sources/changelog.rst
+++ b/docs/sources/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :release:`to be discussed`
+* :bug: SQLite handler (handler.py) insert_execution_context() function: query needed to be updated (removing paranthesis)
 * :feature: `#65` Also monitor failed test as default and add flag `--no-failed` to turn monitoring failed tests off.
 * :feature: `#77` Add a PostgreSQL backend implementation to optionally use a PostgreSQL Database for test metric logging.
 * :bug: `#79` Fix a bug concerning commandline flag `--no-monitor` causing tests that are supposed to fail to pass instead

--- a/pytest_monitor/handler.py
+++ b/pytest_monitor/handler.py
@@ -96,7 +96,7 @@ class SqliteDBHandler:
         self.__cnx.execute(
             "insert into EXECUTION_CONTEXTS(CPU_COUNT,CPU_FREQUENCY_MHZ,CPU_TYPE,CPU_VENDOR,"
             "RAM_TOTAL_MB,MACHINE_NODE,MACHINE_TYPE,MACHINE_ARCH,SYSTEM_INFO,"
-            "PYTHON_INFO,ENV_H) SELECT (?,?,?,?,?,?,?,?,?,?,?)"
+            "PYTHON_INFO,ENV_H) SELECT ?,?,?,?,?,?,?,?,?,?,?"
             " WHERE NOT EXISTS (SELECT 1 FROM EXECUTION_CONTEXTS WHERE ENV_H = ?)",
             (
                 exc_context.cpu_count,


### PR DESCRIPTION
# Description

The where not exist query in the function mentioned in the title did need to be adjusted to the SQLite3 dialect. This meant removing the paranthesis around the first SELECT statement before the WHERE NOT EXISTS part.

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
~- [] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
- [x] My changes generate no new warnings
~- [ ] I have added tests that prove my fix is effective or that my feature works~
- [x] New and existing unit tests pass locally with my changes (not just the [CI](https://link.to.ci))
~- [ ] Any dependent changes have been merged and published in downstream modules~
~- [ ] I have provided a link to the issue this PR adresses in the Description section above (If there is none yet,
[create one](https://github.com/CFMTech/pytest-monitor/issues) !)~
- [x] I have updated the [changelog](https://github.com/CFMTech/pytest-monitor/blob/master/docs/sources/changelog.rst)
~- [ ] I have labeled my PR using appropriate tags (in particular using status labels like [`Status: Code Review Needed`](https://github.com/jsd-spif/pymonitor/labels/Status%3A%20Code%20Review%20Needed), [`Business: Test Needed`](https://github.com/jsd-spif/pymonitor/labels/Business%3A%20Test%20Needed) or [`Status: In Progress`](https://github.com/jsd-spif/pymonitor/labels/Status%3A%20In%20Progress) if you are still working on the PR)~

Request for review @Veritogen 